### PR TITLE
fix: no endpoint extension screen

### DIFF
--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -200,7 +200,7 @@ export default function App() {
             summary={summary}
           />
         ) : (
-          <EmptyPanel title="Run a scan first" body="Findings appear here after a workspace scan." />
+          <EmptyPanel title="No findings!" body="There are no endpoints" />
         )
       )}
       {screen === "simulate" && (


### PR DESCRIPTION
Update Findings panel empty state copy
Replace stale empty state copy in the Findings panel. The previous strings referenced running a scan first, but that state is no longer reachable — the panel now only appears post-scan with zero results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the empty state message displayed in the findings screen when no scan results are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->