### PR TITLE
chore: github push test marker

### DIFF
--- a/.github-push-test.txt
+++ b/.github-push-test.txt
@@ -1,0 +1,1 @@
+GitHub push test — 2026-05-12


### PR DESCRIPTION
Sanity check that the Claude Code GitHub integration can push to `recost-dev/extension` after re-authorizing the App with Contents: write.

Adds a one-line marker file (`.github-push-test.txt`). Safe to close without merging once the push path is confirmed working.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SeyWr5ipp4EhGe2QBxpw5y)_