### PR TITLE
chore(cloud): add SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+# Installs npm dependencies for the three workspaces (root extension,
+# webview, dashboard) so tests, type-checks, and builds can run.
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) environments.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+install_workspace() {
+  local dir="$1"
+  if [ ! -f "$dir/package.json" ]; then
+    echo "skip: $dir (no package.json)"
+    return 0
+  fi
+  echo "==> npm install in $dir"
+  (cd "$dir" && npm install --no-audit --no-fund --loglevel=error)
+}
+
+install_workspace "$ROOT"
+install_workspace "$ROOT/webview"
+install_workspace "$ROOT/dashboard"
+
+echo "SessionStart hook complete."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@ npm-debug.log*
 .wrangler/
 
 # LLM coding assistant directories
-.claude/
+.claude/*
+!.claude/hooks/
+!.claude/settings.json
 .cursor/
 .windsurf/
 .aider/


### PR DESCRIPTION
## Summary
- Adds `.claude/hooks/session-start.sh` — installs npm deps for root, `webview/`, and `dashboard/` workspaces on session start (web only, guarded by `$CLAUDE_CODE_REMOTE`).
- Registers the hook in `.claude/settings.json` as a synchronous `SessionStart` command.
- Updates `.gitignore` to keep `.claude/` ignored by default but track `.claude/hooks/` and `.claude/settings.json`.

## Test plan
- [x] Hook runs cleanly: `CLAUDE_CODE_REMOTE=true ./.claude/hooks/session-start.sh` → installs 44 + 91 + 216 packages, exits 0.
- [x] Type-check: `npx tsc -p tsconfig.scanner-tests.json --noEmit` → exit 0.
- [x] Single test: `node dist-test/test/endpoint-classification.test.js` → 5 / 5 pass.
- [x] Resume verified: SessionStart resume reported "up to date" for all three workspaces.

Mode: **synchronous** — guarantees deps are ready before the agent starts work, at the cost of slightly longer session startup. Can be switched to async on request.

---
_Generated by [Claude Code](https://claude.ai/code/session_018AmdKSsPGeBTL8uzP8hDLm)_