### PR TITLE
docs: clarify SDK local-mode IPC seam; close #91 + #99

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,8 @@ The AST layer (`src/ast/`) uses web-tree-sitter (WASM) to parse JS/TS/Python sou
 
 There is no embedded HTTP server. All "local" data (sustainability footprint, cost-by-provider, simulator runs, scenario CRUD) is computed on the extension host and delivered to the webview through typed IPC messages defined in `src/messages.ts`. Scenarios are persisted via `vscode.globalState` under `eco.simulatorScenarios`.
 
+**SDK "local mode" (runtime telemetry) is not consumed by this extension.** The Node and Python middleware SDKs (`recost-dev/middleware-node`, `recost-dev/middleware-python`) ship a separate "local mode" transport that targets `ws://127.0.0.1:9847`. The extension does not host that server and intentionally will not — the IPC seam here is VS Code's webview-message channel, not localhost sockets. The SDKs are switching local-mode default to a file-based transport tracked in `recost-dev/middleware-node#37` and `recost-dev/middleware-python#38`; the extension is not a consumer of those files either.
+
 ### Auth / API Key System
 
 Two separate key systems coexist:


### PR DESCRIPTION
## Summary

- Documents in `CLAUDE.md` that the SDK "local mode" WebSocket transport (`ws://127.0.0.1:9847`) is **not** consumed by the extension, and intentionally will not be — the extension's IPC seam is VS Code's webview-message channel, not localhost sockets.
- Records the decision to replace SDK local-mode with a file-based (NDJSON) transport, tracked in the sibling repos.
- Closes both Wave 9 issues with no code changes in this repo.

## Follow-up issues in sibling repos

- recost-dev/middleware-node#37 — Add JSON-file local-mode transport (alternative to WebSocket)
- recost-dev/middleware-python#38 — mirror

Both flip SDK local-mode default to `file` and add a top-level `protocolVersion: "1.0"` field to every `WindowSummary` frame (which subsumes #99 for the file path). WS local mode remains as opt-in.

## Test plan

- [ ] Review `CLAUDE.md` diff reads cleanly and the linked issue numbers resolve on GitHub.
- [ ] Confirm #91 and #99 auto-close on merge.

Closes #91
Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)