### PR TITLE
chore(claude): enable recost plugin marketplace with superpowers + design-toolkit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,5 +10,17 @@
         ]
       }
     ]
+  },
+  "extraKnownMarketplaces": {
+    "recost": {
+      "source": {
+        "source": "github",
+        "repo": "recost-dev/claude-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "design-toolkit@recost": true,
+    "superpowers@recost": true
   }
 }


### PR DESCRIPTION
Registers the recost-dev/claude-plugins marketplace and enables the
superpowers and design-toolkit plugins for local Claude Code CLI sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for the recost marketplace has been added
  * Two new plugins are now available: design toolkit and superpowers
  * New marketplace plugins are ready for immediate use

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/recost-dev/extension/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->